### PR TITLE
feat: add vault list command

### DIFF
--- a/internal/cli/commands/cmdvault/list.go
+++ b/internal/cli/commands/cmdvault/list.go
@@ -75,7 +75,7 @@ Use --details to show vault metadata.`,
 				if showDetails {
 					displayVaultsWithDetails(dir, vaultFiles)
 				} else {
-					displayVaultsList(vaultFiles)
+					displayVaultsList(dir, vaultFiles)
 				}
 			},
 		}
@@ -87,34 +87,109 @@ Use --details to show vault metadata.`,
 	return vaultListCmd
 }
 
-func displayVaultsList(vaultFiles []string) {
+func displayVaultsList(baseDir string, vaultFiles []string) {
 	fmt.Printf("Found %d vault(s):\n\n", len(vaultFiles))
-	for _, vaultFile := range vaultFiles {
-		fmt.Printf("  • %s\n", vaultFile)
+	
+	for i, vaultFile := range vaultFiles {
+		fullPath := filepath.Join(baseDir, vaultFile)
+		vault, err := vaults.Get(fullPath)
+		
+		// Display vault number and path
+		fmt.Printf("%d. %s\n", i+1, text.Colors{text.Bold, text.FgCyan}.Sprint(vaultFile))
+		
+		if err != nil {
+			fmt.Printf("   %s\n\n", text.Colors{text.FgRed}.Sprint("⚠ Error loading vault"))
+			continue
+		}
+		
+		// Get vault metadata
+		vaultName := vault.Name
+		if vaultName == "" {
+			vaultName = text.Colors{text.Faint}.Sprint("(unnamed)")
+		} else {
+			vaultName = text.Colors{text.FgGreen}.Sprint(vaultName)
+		}
+		
+		namespace := vault.Namespace
+		if namespace == "" {
+			namespace = text.Colors{text.Faint}.Sprint("(default)")
+		}
+		
+		// Count secrets
+		itemNames := vault.GetItemNames()
+		secretCount := len(itemNames)
+		
+		// Count accessors
+		accessors, err := vault.ListAccessors()
+		accessorCount := 0
+		if err == nil {
+			accessorCount = len(accessors)
+		}
+		
+		// Display details in a readable format
+		fmt.Printf("   Name:       %s\n", vaultName)
+		fmt.Printf("   Namespace:  %s\n", namespace)
+		fmt.Printf("   Secrets:    %s\n", text.Colors{text.Bold}.Sprintf("%d", secretCount))
+		fmt.Printf("   Accessors:  %s\n", text.Colors{text.Bold}.Sprintf("%d", accessorCount))
+		
+		// Show accessor details if available
+		if accessorCount > 0 && len(accessors) > 0 {
+			fmt.Printf("   Accessible by: ")
+			for idx, accessor := range accessors {
+				if idx > 0 {
+					fmt.Printf(", ")
+				}
+				accStr, err := accessor.String()
+				if err == nil {
+					// Show truncated accessor key
+					if len(accStr) > 16 {
+						fmt.Printf("%s", text.Colors{text.FgYellow}.Sprintf("%s...", accStr[:16]))
+					} else {
+						fmt.Printf("%s", text.Colors{text.FgYellow}.Sprint(accStr))
+					}
+				}
+				if idx >= 2 { // Show max 3 accessors
+					remaining := len(accessors) - 3
+					if remaining > 0 {
+						fmt.Printf(" %s", text.Colors{text.Faint}.Sprintf("+%d more", remaining))
+					}
+					break
+				}
+			}
+			fmt.Println()
+		}
+		
+		fmt.Println()
 	}
-	fmt.Println()
-	fmt.Println("Use 'slv vault list --details' to see more information.")
+	
+	fmt.Println(text.Colors{text.Faint}.Sprint("💡 Tip: Use 'slv vault list --details' for table view"))
 }
 
 func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
+	fmt.Printf("Found %d vault(s):\n\n", len(vaultFiles))
+	
 	vaultTable := table.NewWriter()
 	vaultTable.SetOutputMirror(os.Stdout)
 	vaultTable.AppendHeader(table.Row{
+		text.Colors{text.Bold}.Sprint("#"),
 		text.Colors{text.Bold}.Sprint("Vault File"),
 		text.Colors{text.Bold}.Sprint("Name"),
 		text.Colors{text.Bold}.Sprint("Namespace"),
 		text.Colors{text.Bold}.Sprint("Secrets"),
 		text.Colors{text.Bold}.Sprint("Accessors"),
+		text.Colors{text.Bold}.Sprint("Access List"),
 	})
 
-	for _, vaultFile := range vaultFiles {
+	for idx, vaultFile := range vaultFiles {
 		fullPath := filepath.Join(baseDir, vaultFile)
 		vault, err := vaults.Get(fullPath)
 		if err != nil {
 			// If we can't load the vault, show basic info with error
 			vaultTable.AppendRow(table.Row{
+				fmt.Sprintf("%d", idx+1),
 				vaultFile,
 				text.Colors{text.FgRed}.Sprint("(Error loading)"),
+				"-",
 				"-",
 				"-",
 				"-",
@@ -125,12 +200,12 @@ func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
 		// Get vault metadata
 		vaultName := vault.Name
 		if vaultName == "" {
-			vaultName = "-"
+			vaultName = text.Colors{text.Faint}.Sprint("(unnamed)")
 		}
 
 		namespace := vault.Namespace
 		if namespace == "" {
-			namespace = "-"
+			namespace = text.Colors{text.Faint}.Sprint("(default)")
 		}
 
 		// Count secrets
@@ -140,21 +215,93 @@ func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
 		// Count accessors
 		accessors, err := vault.ListAccessors()
 		accessorCount := 0
+		accessorList := "-"
 		if err == nil {
 			accessorCount = len(accessors)
+			if accessorCount > 0 {
+				if accessorCount <= 2 {
+					accessorList = ""
+					for i, acc := range accessors {
+						if i > 0 {
+							accessorList += ", "
+						}
+						accStr, err := acc.String()
+						if err == nil {
+							// Show first 12 characters of the accessor
+							if len(accStr) > 12 {
+								accessorList += accStr[:12] + "..."
+							} else {
+								accessorList += accStr
+							}
+						}
+					}
+				} else {
+					// Show first accessor and count
+					accStr, err := accessors[0].String()
+					if err == nil {
+						if len(accStr) > 12 {
+							accessorList = fmt.Sprintf("%s... +%d more", accStr[:12], accessorCount-1)
+						} else {
+							accessorList = fmt.Sprintf("%s +%d more", accStr, accessorCount-1)
+						}
+					} else {
+						accessorList = fmt.Sprintf("%d accessors", accessorCount)
+					}
+				}
+			}
 		}
 
 		vaultTable.AppendRow(table.Row{
+			fmt.Sprintf("%d", idx+1),
 			vaultFile,
 			vaultName,
 			namespace,
 			fmt.Sprintf("%d", secretCount),
 			fmt.Sprintf("%d", accessorCount),
+			accessorList,
 		})
 	}
-
-	fmt.Printf("Found %d vault(s):\n\n", len(vaultFiles))
+	
+	// Table styling with proper wrapping for terminal readability
 	vaultTable.SetStyle(table.StyleLight)
+	vaultTable.Style().Options.SeparateRows = false
+	vaultTable.Style().Options.SeparateColumns = true
+	vaultTable.Style().Options.DrawBorder = true
+	
+	// Set column configurations with wrapping enabled inside cells
+	vaultTable.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 1, Align: text.AlignCenter, WidthMax: 4, WidthMin: 3},                        // #
+		{Number: 2, AutoMerge: false, WidthMax: 30, WidthMin: 20, Align: text.AlignLeft},      // Vault File
+		{Number: 3, AutoMerge: false, WidthMax: 18, WidthMin: 10, Align: text.AlignLeft},      // Name
+		{Number: 4, AutoMerge: false, WidthMax: 12, WidthMin: 10, Align: text.AlignLeft},      // Namespace
+		{Number: 5, Align: text.AlignRight, WidthMax: 8, WidthMin: 8},                         // Secrets
+		{Number: 6, Align: text.AlignRight, WidthMax: 10, WidthMin: 10},                       // Accessors
+		{Number: 7, AutoMerge: false, WidthMax: 25, WidthMin: 12, Align: text.AlignLeft},      // Access List
+	})
+	
 	vaultTable.Render()
+	
+	// Add summary footer
+	fmt.Println()
+	totalSecrets := 0
+	totalAccessors := 0
+	for _, vaultFile := range vaultFiles {
+		fullPath := filepath.Join(baseDir, vaultFile)
+		vault, err := vaults.Get(fullPath)
+		if err != nil {
+			continue
+		}
+		totalSecrets += len(vault.GetItemNames())
+		accessors, err := vault.ListAccessors()
+		if err == nil {
+			totalAccessors += len(accessors)
+		}
+	}
+	
+	fmt.Printf("📊 Summary: %s vaults | %s total secrets | %s unique accessors\n",
+		text.Colors{text.Bold}.Sprintf("%d", len(vaultFiles)),
+		text.Colors{text.Bold, text.FgGreen}.Sprintf("%d", totalSecrets),
+		text.Colors{text.Bold, text.FgCyan}.Sprintf("%d", totalAccessors),
+	)
 	fmt.Println()
 }

--- a/internal/cli/commands/cmdvault/list.go
+++ b/internal/cli/commands/cmdvault/list.go
@@ -89,80 +89,11 @@ Use --details to show vault metadata.`,
 
 func displayVaultsList(baseDir string, vaultFiles []string) {
 	fmt.Printf("Found %d vault(s):\n\n", len(vaultFiles))
-	
-	for i, vaultFile := range vaultFiles {
-		fullPath := filepath.Join(baseDir, vaultFile)
-		vault, err := vaults.Get(fullPath)
-		
-		// Display vault number and path
-		fmt.Printf("%d. %s\n", i+1, text.Colors{text.Bold, text.FgCyan}.Sprint(vaultFile))
-		
-		if err != nil {
-			fmt.Printf("   %s\n\n", text.Colors{text.FgRed}.Sprint("⚠ Error loading vault"))
-			continue
-		}
-		
-		// Get vault metadata
-		vaultName := vault.Name
-		if vaultName == "" {
-			vaultName = text.Colors{text.Faint}.Sprint("(unnamed)")
-		} else {
-			vaultName = text.Colors{text.FgGreen}.Sprint(vaultName)
-		}
-		
-		namespace := vault.Namespace
-		if namespace == "" {
-			namespace = text.Colors{text.Faint}.Sprint("(default)")
-		}
-		
-		// Count secrets
-		itemNames := vault.GetItemNames()
-		secretCount := len(itemNames)
-		
-		// Count accessors
-		accessors, err := vault.ListAccessors()
-		accessorCount := 0
-		if err == nil {
-			accessorCount = len(accessors)
-		}
-		
-		// Display details in a readable format
-		fmt.Printf("   Name:       %s\n", vaultName)
-		fmt.Printf("   Namespace:  %s\n", namespace)
-		fmt.Printf("   Secrets:    %s\n", text.Colors{text.Bold}.Sprintf("%d", secretCount))
-		fmt.Printf("   Accessors:  %s\n", text.Colors{text.Bold}.Sprintf("%d", accessorCount))
-		
-		// Show accessor details if available
-		if accessorCount > 0 && len(accessors) > 0 {
-			fmt.Printf("   Accessible by: ")
-			for idx, accessor := range accessors {
-				if idx > 0 {
-					fmt.Printf(", ")
-				}
-				accStr, err := accessor.String()
-				if err == nil {
-					// Show truncated accessor key
-					if len(accStr) > 16 {
-						fmt.Printf("%s", text.Colors{text.FgYellow}.Sprintf("%s...", accStr[:16]))
-					} else {
-						fmt.Printf("%s", text.Colors{text.FgYellow}.Sprint(accStr))
-					}
-				}
-				if idx >= 2 { // Show max 3 accessors
-					remaining := len(accessors) - 3
-					if remaining > 0 {
-						fmt.Printf(" %s", text.Colors{text.Faint}.Sprintf("+%d more", remaining))
-					}
-					break
-				}
-			}
-			fmt.Println()
-		}
-		
-		fmt.Println()
+	for _, vaultFile := range vaultFiles {
+		fmt.Printf("  • %s\n", vaultFile)
 	}
-	
-	fmt.Println(text.Colors{text.Faint}.Sprint("💡 Tip: Use 'slv vault list --details' for table view"))
+	fmt.Println()
+	fmt.Println("Use 'slv vault list --details' to see more information.")
 }
 
 func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
@@ -171,25 +102,21 @@ func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
 	vaultTable := table.NewWriter()
 	vaultTable.SetOutputMirror(os.Stdout)
 	vaultTable.AppendHeader(table.Row{
-		text.Colors{text.Bold}.Sprint("#"),
 		text.Colors{text.Bold}.Sprint("Vault File"),
 		text.Colors{text.Bold}.Sprint("Name"),
 		text.Colors{text.Bold}.Sprint("Namespace"),
 		text.Colors{text.Bold}.Sprint("Secrets"),
 		text.Colors{text.Bold}.Sprint("Accessors"),
-		text.Colors{text.Bold}.Sprint("Access List"),
 	})
 
-	for idx, vaultFile := range vaultFiles {
+	for _, vaultFile := range vaultFiles {
 		fullPath := filepath.Join(baseDir, vaultFile)
 		vault, err := vaults.Get(fullPath)
 		if err != nil {
 			// If we can't load the vault, show basic info with error
 			vaultTable.AppendRow(table.Row{
-				fmt.Sprintf("%d", idx+1),
 				vaultFile,
 				text.Colors{text.FgRed}.Sprint("(Error loading)"),
-				"-",
 				"-",
 				"-",
 				"-",
@@ -200,12 +127,12 @@ func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
 		// Get vault metadata
 		vaultName := vault.Name
 		if vaultName == "" {
-			vaultName = text.Colors{text.Faint}.Sprint("(unnamed)")
+			vaultName = "-"
 		}
 
 		namespace := vault.Namespace
 		if namespace == "" {
-			namespace = text.Colors{text.Faint}.Sprint("(default)")
+			namespace = "-"
 		}
 
 		// Count secrets
@@ -215,50 +142,16 @@ func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
 		// Count accessors
 		accessors, err := vault.ListAccessors()
 		accessorCount := 0
-		accessorList := "-"
 		if err == nil {
 			accessorCount = len(accessors)
-			if accessorCount > 0 {
-				if accessorCount <= 2 {
-					accessorList = ""
-					for i, acc := range accessors {
-						if i > 0 {
-							accessorList += ", "
-						}
-						accStr, err := acc.String()
-						if err == nil {
-							// Show first 12 characters of the accessor
-							if len(accStr) > 12 {
-								accessorList += accStr[:12] + "..."
-							} else {
-								accessorList += accStr
-							}
-						}
-					}
-				} else {
-					// Show first accessor and count
-					accStr, err := accessors[0].String()
-					if err == nil {
-						if len(accStr) > 12 {
-							accessorList = fmt.Sprintf("%s... +%d more", accStr[:12], accessorCount-1)
-						} else {
-							accessorList = fmt.Sprintf("%s +%d more", accStr, accessorCount-1)
-						}
-					} else {
-						accessorList = fmt.Sprintf("%d accessors", accessorCount)
-					}
-				}
-			}
 		}
 
 		vaultTable.AppendRow(table.Row{
-			fmt.Sprintf("%d", idx+1),
 			vaultFile,
 			vaultName,
 			namespace,
 			fmt.Sprintf("%d", secretCount),
 			fmt.Sprintf("%d", accessorCount),
-			accessorList,
 		})
 	}
 	
@@ -270,38 +163,13 @@ func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
 	
 	// Set column configurations with wrapping enabled inside cells
 	vaultTable.SetColumnConfigs([]table.ColumnConfig{
-		{Number: 1, Align: text.AlignCenter, WidthMax: 4, WidthMin: 3},                        // #
-		{Number: 2, AutoMerge: false, WidthMax: 30, WidthMin: 20, Align: text.AlignLeft},      // Vault File
-		{Number: 3, AutoMerge: false, WidthMax: 18, WidthMin: 10, Align: text.AlignLeft},      // Name
-		{Number: 4, AutoMerge: false, WidthMax: 12, WidthMin: 10, Align: text.AlignLeft},      // Namespace
-		{Number: 5, Align: text.AlignRight, WidthMax: 8, WidthMin: 8},                         // Secrets
-		{Number: 6, Align: text.AlignRight, WidthMax: 10, WidthMin: 10},                       // Accessors
-		{Number: 7, AutoMerge: false, WidthMax: 25, WidthMin: 12, Align: text.AlignLeft},      // Access List
+		{Number: 1, AutoMerge: false, WidthMax: 35, WidthMin: 20, Align: text.AlignLeft},      // Vault File
+		{Number: 2, AutoMerge: false, WidthMax: 20, WidthMin: 10, Align: text.AlignLeft},      // Name
+		{Number: 3, AutoMerge: false, WidthMax: 15, WidthMin: 10, Align: text.AlignLeft},      // Namespace
+		{Number: 4, Align: text.AlignRight, WidthMax: 8, WidthMin: 8},                         // Secrets
+		{Number: 5, Align: text.AlignRight, WidthMax: 10, WidthMin: 10},                       // Accessors
 	})
 	
 	vaultTable.Render()
-	
-	// Add summary footer
-	fmt.Println()
-	totalSecrets := 0
-	totalAccessors := 0
-	for _, vaultFile := range vaultFiles {
-		fullPath := filepath.Join(baseDir, vaultFile)
-		vault, err := vaults.Get(fullPath)
-		if err != nil {
-			continue
-		}
-		totalSecrets += len(vault.GetItemNames())
-		accessors, err := vault.ListAccessors()
-		if err == nil {
-			totalAccessors += len(accessors)
-		}
-	}
-	
-	fmt.Printf("📊 Summary: %s vaults | %s total secrets | %s unique accessors\n",
-		text.Colors{text.Bold}.Sprintf("%d", len(vaultFiles)),
-		text.Colors{text.Bold, text.FgGreen}.Sprintf("%d", totalSecrets),
-		text.Colors{text.Bold, text.FgCyan}.Sprintf("%d", totalAccessors),
-	)
 	fmt.Println()
 }

--- a/internal/cli/commands/cmdvault/list.go
+++ b/internal/cli/commands/cmdvault/list.go
@@ -1,0 +1,160 @@
+package cmdvault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"slv.sh/slv/internal/cli/commands/utils"
+	"slv.sh/slv/internal/core/vaults"
+	"slv.sh/slv/internal/helpers"
+)
+
+var (
+	vaultListCmd *cobra.Command
+
+	listDirFlag = utils.FlagDef{
+		Name:      "dir",
+		Shorthand: "d",
+		Usage:     "Directory to search for vaults (default: current directory)",
+	}
+
+	listRecursiveFlag = utils.FlagDef{
+		Name:      "recursive",
+		Shorthand: "r",
+		Usage:     "Search for vaults recursively in subdirectories",
+	}
+
+	listShowDetailsFlag = utils.FlagDef{
+		Name:      "details",
+		Shorthand: "l",
+		Usage:     "Show detailed information about each vault",
+	}
+)
+
+func vaultListCommand() *cobra.Command {
+	if vaultListCmd == nil {
+		vaultListCmd = &cobra.Command{
+			Use:     "list",
+			Aliases: []string{"ls", "find", "search"},
+			Short:   "List all vaults in a directory",
+			Long: `List all vault files in the specified directory.
+By default, lists vaults in the current directory.
+Use --recursive to search in subdirectories.
+Use --details to show vault metadata.`,
+			PreRun: func(cmd *cobra.Command, args []string) {
+				// The list command doesn't need the vault flag
+				cmd.Parent().PersistentFlags().Lookup(vaultFileFlag.Name).Changed = true
+			},
+			Run: func(cmd *cobra.Command, args []string) {
+				dir := cmd.Flag(listDirFlag.Name).Value.String()
+				recursive, _ := cmd.Flags().GetBool(listRecursiveFlag.Name)
+				showDetails, _ := cmd.Flags().GetBool(listShowDetailsFlag.Name)
+
+				if dir == "" {
+					var err error
+					dir, err = os.Getwd()
+					if err != nil {
+						utils.ExitOnError(err)
+					}
+				}
+
+				vaultFiles, err := helpers.ListVaultFiles(dir, recursive)
+				if err != nil {
+					utils.ExitOnError(err)
+				}
+
+				if len(vaultFiles) == 0 {
+					fmt.Println("No vaults found in the specified directory.")
+					utils.SafeExit()
+				}
+
+				if showDetails {
+					displayVaultsWithDetails(dir, vaultFiles)
+				} else {
+					displayVaultsList(vaultFiles)
+				}
+			},
+		}
+
+		vaultListCmd.Flags().StringP(listDirFlag.Name, listDirFlag.Shorthand, "", listDirFlag.Usage)
+		vaultListCmd.Flags().BoolP(listRecursiveFlag.Name, listRecursiveFlag.Shorthand, false, listRecursiveFlag.Usage)
+		vaultListCmd.Flags().BoolP(listShowDetailsFlag.Name, listShowDetailsFlag.Shorthand, false, listShowDetailsFlag.Usage)
+	}
+	return vaultListCmd
+}
+
+func displayVaultsList(vaultFiles []string) {
+	fmt.Printf("Found %d vault(s):\n\n", len(vaultFiles))
+	for _, vaultFile := range vaultFiles {
+		fmt.Printf("  • %s\n", vaultFile)
+	}
+	fmt.Println()
+	fmt.Println("Use 'slv vault list --details' to see more information.")
+}
+
+func displayVaultsWithDetails(baseDir string, vaultFiles []string) {
+	vaultTable := table.NewWriter()
+	vaultTable.SetOutputMirror(os.Stdout)
+	vaultTable.AppendHeader(table.Row{
+		text.Colors{text.Bold}.Sprint("Vault File"),
+		text.Colors{text.Bold}.Sprint("Name"),
+		text.Colors{text.Bold}.Sprint("Namespace"),
+		text.Colors{text.Bold}.Sprint("Secrets"),
+		text.Colors{text.Bold}.Sprint("Accessors"),
+	})
+
+	for _, vaultFile := range vaultFiles {
+		fullPath := filepath.Join(baseDir, vaultFile)
+		vault, err := vaults.Get(fullPath)
+		if err != nil {
+			// If we can't load the vault, show basic info with error
+			vaultTable.AppendRow(table.Row{
+				vaultFile,
+				text.Colors{text.FgRed}.Sprint("(Error loading)"),
+				"-",
+				"-",
+				"-",
+			})
+			continue
+		}
+
+		// Get vault metadata
+		vaultName := vault.Name
+		if vaultName == "" {
+			vaultName = "-"
+		}
+
+		namespace := vault.Namespace
+		if namespace == "" {
+			namespace = "-"
+		}
+
+		// Count secrets
+		itemNames := vault.GetItemNames()
+		secretCount := len(itemNames)
+
+		// Count accessors
+		accessors, err := vault.ListAccessors()
+		accessorCount := 0
+		if err == nil {
+			accessorCount = len(accessors)
+		}
+
+		vaultTable.AppendRow(table.Row{
+			vaultFile,
+			vaultName,
+			namespace,
+			fmt.Sprintf("%d", secretCount),
+			fmt.Sprintf("%d", accessorCount),
+		})
+	}
+
+	fmt.Printf("Found %d vault(s):\n\n", len(vaultFiles))
+	vaultTable.SetStyle(table.StyleLight)
+	vaultTable.Render()
+	fmt.Println()
+}

--- a/internal/cli/commands/cmdvault/vault.go
+++ b/internal/cli/commands/cmdvault/vault.go
@@ -144,6 +144,7 @@ func VaultCommand() *cobra.Command {
 		if err := vaultCmd.RegisterFlagCompletionFunc(vaultFileFlag.Name, vaultFilePathCompletion); err != nil {
 			utils.ExitOnError(err)
 		}
+		vaultCmd.AddCommand(vaultListCommand())
 		vaultCmd.AddCommand(vaultNewCommand())
 		vaultCmd.AddCommand(vaultUpdateCommand())
 		vaultCmd.AddCommand(vaultPutCommand())

--- a/website/docs/command-reference/vault/list.md
+++ b/website/docs/command-reference/vault/list.md
@@ -1,0 +1,269 @@
+---
+sidebar_position: 1
+---
+
+# List Vaults
+
+List all vault files in a directory.
+
+## Overview
+
+The `list` command scans a directory for SLV vault files (`.slv.yaml` or `.slv.yml`) and displays them as a simple list or detailed table. Useful for:
+
+- Finding vaults in a new project
+- Getting an overview of all vaults
+- Searching nested directories
+- Checking vault metadata without unlocking
+
+## General Usage
+
+```bash
+slv vault list [flags]
+```
+
+### Aliases
+
+The following aliases are available:
+- `slv vault list`
+- `slv vault ls`
+- `slv vault find`
+- `slv vault search`
+
+## Flags
+
+| Flag | Shorthand | Arguments | Default | Description |
+| -- | -- | -- | -- | -- |
+| --dir | -d | String | Current directory | Directory to search for vaults |
+| --recursive | -r | None | false | Search recursively in subdirectories |
+| --details | -l | None | false | Show detailed information (name, namespace, secret count, accessors) |
+| --help | -h | None | NA | Help text for `slv vault list` |
+
+---
+
+## How It Works
+
+### Basic List
+
+By default, the command lists vault files in the current directory:
+
+```bash
+slv vault list
+```
+
+**Output:**
+```
+Found 3 vault(s):
+
+  • dev.slv.yaml
+  • staging.slv.yaml
+  • prod.slv.yaml
+
+Use 'slv vault list --details' to see more information.
+```
+
+### Recursive Search
+
+Search for vaults in all subdirectories:
+
+```bash
+slv vault list --recursive
+```
+
+**Output:**
+```
+Found 5 vault(s):
+
+  • dev.slv.yaml
+  • prod.slv.yaml
+  • team/backend.slv.yaml
+  • team/frontend.slv.yaml
+  • secrets/api-keys.slv.yaml
+
+Use 'slv vault list --details' to see more information.
+```
+
+### Detailed View
+
+Show metadata for each vault:
+
+```bash
+slv vault list --recursive --details
+```
+
+**Short form:**
+```bash
+slv vault ls -r -l
+```
+
+**Output:**
+```
+Found 5 vault(s):
+
+┌──────────────────────────┬───────────┬───────────┬─────────┬───────────┐
+│ VAULT FILE               │ NAME      │ NAMESPACE │ SECRETS │ ACCESSORS │
+├──────────────────────────┼───────────┼───────────┼─────────┼───────────┤
+│ dev.slv.yaml             │ dev-env   │ default   │ 12      │ 3         │
+│ prod.slv.yaml            │ prod-env  │ prod      │ 8       │ 2         │
+│ team/backend.slv.yaml    │ backend   │ team      │ 15      │ 5         │
+│ team/frontend.slv.yaml   │ frontend  │ team      │ 10      │ 4         │
+│ secrets/api-keys.slv.yaml│ api-keys  │ -         │ 6       │ 2         │
+└──────────────────────────┴───────────┴───────────┴─────────┴───────────┘
+```
+
+### Specify Directory
+
+List vaults in a specific directory:
+
+```bash
+slv vault list --dir /path/to/project
+```
+
+**Or with a relative path:**
+```bash
+slv vault ls -d ~/projects/myapp -r
+```
+
+---
+
+## Examples
+
+### Example 1: Quick Vault Discovery
+
+Find all vaults in your current project:
+
+```bash
+cd /path/to/project
+slv vault ls -r
+```
+
+```
+Found 3 vault(s):
+
+  • config/dev.slv.yaml
+  • config/prod.slv.yaml
+  • infrastructure/secrets.slv.yaml
+
+Use 'slv vault list --details' to see more information.
+```
+
+### Example 2: Audit Vault Statistics
+
+Get detailed statistics about all vaults:
+
+```bash
+slv vault list -r -l
+```
+
+```
+Found 3 vault(s):
+
+┌──────────────────────────────┬──────────┬───────────┬─────────┬───────────┐
+│ VAULT FILE                   │ NAME     │ NAMESPACE │ SECRETS │ ACCESSORS │
+├──────────────────────────────┼──────────┼───────────┼─────────┼───────────┤
+│ config/dev.slv.yaml          │ dev      │ default   │ 25      │ 8         │
+│ config/prod.slv.yaml         │ prod     │ prod      │ 12      │ 3         │
+│ infrastructure/secrets.slv...│ infra    │ -         │ 5       │ 2         │
+└──────────────────────────────┴──────────┴───────────┴─────────┴───────────┘
+```
+
+The output shows:
+- 25 secrets in dev vault, accessible by 8 environments
+- 12 secrets in prod vault, accessible by 3 environments
+- 5 secrets in infrastructure vault, accessible by 2 environments
+
+### Example 3: Search Specific Directory
+
+List vaults in a specific project without changing directories:
+
+```bash
+slv vault find --dir ~/projects/my-app --recursive
+```
+
+### Example 4: CI/CD Validation
+
+Check if vaults exist in your repository:
+
+```bash
+if slv vault list -r | grep -q "Found 0 vault"; then
+  echo "No vaults found - please create vaults"
+  exit 1
+fi
+```
+
+---
+
+## Use Cases
+
+### 1. New Project Onboarding
+
+List all vaults when joining a new project:
+
+```bash
+slv vault list -r -l
+```
+
+Shows all vaults with secret counts and environment access.
+
+### 2. Vault Organization
+
+Find all vaults in the project:
+
+```bash
+slv vault find -r
+```
+
+Useful for identifying duplicate vaults and understanding vault structure.
+
+### 3. Security Audit
+
+Audit vault distribution and access:
+
+```bash
+slv vault ls -r -l
+```
+
+Review secret counts, accessor counts, and vault organization.
+
+### 4. Documentation
+
+Generate vault inventory for documentation:
+
+```bash
+slv vault list -r -l > vault-inventory.txt
+```
+
+---
+
+## Features
+
+- Automatically finds `.slv.yaml` and `.slv.yml` files
+- Shows vault statistics without unlocking
+- Recursive directory scanning
+- Fast operation (no vault unlocking required)
+- Works with absolute and relative paths
+- Only displays metadata, never secret values
+
+---
+
+## Notes
+
+- No unlocking required - the command shows basic information without decrypting vaults
+- Locked vaults can still display name, namespace, secret count, and accessor count
+- Corrupted vault files will be shown as "(Error loading)"
+- Fast performance since it only reads metadata
+
+---
+
+## Related Commands
+
+- [Create a New Vault](/docs/command-reference/vault/new) - Create vaults to list
+- [Get a Secret](/docs/command-reference/vault/get) - View secrets in a specific vault
+- [Vault Overview](/docs/components/vault) - Learn more about vaults
+
+---
+
+## Tips
+
+- Use `ls -r -l` for a complete vault infrastructure overview
+- Combine with grep for filtering: `slv vault ls -r | grep prod`
+- Validate vault presence in scripts: `slv vault list -d ./config -r`

--- a/website/docs/command-reference/vault/list.md
+++ b/website/docs/command-reference/vault/list.md
@@ -102,11 +102,11 @@ Found 5 vault(s):
 ┌──────────────────────────┬───────────┬───────────┬─────────┬───────────┐
 │ VAULT FILE               │ NAME      │ NAMESPACE │ SECRETS │ ACCESSORS │
 ├──────────────────────────┼───────────┼───────────┼─────────┼───────────┤
-│ dev.slv.yaml             │ dev-env   │ default   │ 12      │ 3         │
-│ prod.slv.yaml            │ prod-env  │ prod      │ 8       │ 2         │
-│ team/backend.slv.yaml    │ backend   │ team      │ 15      │ 5         │
-│ team/frontend.slv.yaml   │ frontend  │ team      │ 10      │ 4         │
-│ secrets/api-keys.slv.yaml│ api-keys  │ -         │ 6       │ 2         │
+│ dev.slv.yaml             │ dev-env   │ default   │      12 │         3 │
+│ prod.slv.yaml            │ prod-env  │ prod      │       8 │         2 │
+│ team/backend.slv.yaml    │ backend   │ team      │      15 │         5 │
+│ team/frontend.slv.yaml   │ frontend  │ team      │      10 │         4 │
+│ secrets/api-keys.slv.yaml│ api-keys  │ -         │       6 │         2 │
 └──────────────────────────┴───────────┴───────────┴─────────┴───────────┘
 ```
 
@@ -157,13 +157,13 @@ slv vault list -r -l
 ```
 Found 3 vault(s):
 
-┌──────────────────────────────┬──────────┬───────────┬─────────┬───────────┐
-│ VAULT FILE                   │ NAME     │ NAMESPACE │ SECRETS │ ACCESSORS │
-├──────────────────────────────┼──────────┼───────────┼─────────┼───────────┤
-│ config/dev.slv.yaml          │ dev      │ default   │ 25      │ 8         │
-│ config/prod.slv.yaml         │ prod     │ prod      │ 12      │ 3         │
-│ infrastructure/secrets.slv...│ infra    │ -         │ 5       │ 2         │
-└──────────────────────────────┴──────────┴───────────┴─────────┴───────────┘
+┌─────────────────────────┬──────────┬───────────┬─────────┬───────────┐
+│ VAULT FILE              │ NAME     │ NAMESPACE │ SECRETS │ ACCESSORS │
+├─────────────────────────┼──────────┼───────────┼─────────┼───────────┤
+│ config/dev.slv.yaml     │ dev      │ default   │      25 │         8 │
+│ config/prod.slv.yaml    │ prod     │ prod      │      12 │         3 │
+│ infrastructure/secrets..│ infra    │ -         │       5 │         2 │
+└─────────────────────────┴──────────┴───────────┴─────────┴───────────┘
 ```
 
 The output shows:

--- a/website/docs/command-reference/vault/list.md
+++ b/website/docs/command-reference/vault/list.md
@@ -110,6 +110,13 @@ Found 5 vault(s):
 └──────────────────────────┴───────────┴───────────┴─────────┴───────────┘
 ```
 
+:::tip
+To view the list of accessors for a specific vault, use:
+```bash
+slv vault -v /path/to/vault.slv.yaml
+```
+:::
+
 ### Specify Directory
 
 List vaults in a specific directory:
@@ -170,6 +177,11 @@ The output shows:
 - 25 secrets in dev vault, accessible by 8 environments
 - 12 secrets in prod vault, accessible by 3 environments
 - 5 secrets in infrastructure vault, accessible by 2 environments
+
+:::tip
+The **ACCESSORS** column shows the count of environments/profiles that can decrypt this vault.
+To see the actual accessor public keys, use `slv vault -v /path/to/vault.slv.yaml`
+:::
 
 ### Example 3: Search Specific Directory
 

--- a/website/docs/components/vault.md
+++ b/website/docs/components/vault.md
@@ -31,6 +31,7 @@ This makes SLV particularly powerful in collaborative workflows.
 
 ## Related Topics
 
+- [List Vaults](/docs/command-reference/vault/list) - Discover and list all vaults in your project
 - [Create a New Vault](/docs/command-reference/vault/new) - Learn how to create vaults
 - [Put a Secret](/docs/command-reference/vault/put) - Add secrets to your vault
 - [Get a Secret](/docs/command-reference/vault/get) - Retrieve secrets from your vault


### PR DESCRIPTION
Add new command to discover and list vaults in a directory. Supports recursive search and detailed metadata display..

- Add list subcommand with ls/find/search aliases
- Show vault metadata without unlocking
- Support recursive directory scanning
- Display name, namespace, secret count, accessor count
- Add comprehensive documentation

This is one of my first open-source contributions after learning Go for my project.
 