### PR TITLE
feat(helm): Add support for existing service accounts and configurable service account names

### DIFF
--- a/internal/k8s/charts/slv-lib/templates/_clusterrolebinding.tpl
+++ b/internal/k8s/charts/slv-lib/templates/_clusterrolebinding.tpl
@@ -5,7 +5,7 @@ metadata:
   name: slv-rolebinding
 subjects:
 - kind: ServiceAccount
-  name: slv-serviceaccount
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/internal/k8s/charts/slv-lib/templates/_serviceaccount.tpl
+++ b/internal/k8s/charts/slv-lib/templates/_serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: slv-serviceaccount
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccount.labels }}
   labels:

--- a/internal/k8s/charts/slv-operator/templates/clusterrolebinding.yaml
+++ b/internal/k8s/charts/slv-operator/templates/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
   name: slv-webhook-rolebinding
 subjects:
 - kind: ServiceAccount
-  name: slv-serviceaccount
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/internal/k8s/charts/slv-operator/templates/deployment.yaml
+++ b/internal/k8s/charts/slv-operator/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: slv-serviceaccount
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/internal/k8s/charts/slv-operator/templates/serviceaccount.yaml
+++ b/internal/k8s/charts/slv-operator/templates/serviceaccount.yaml
@@ -1,1 +1,3 @@
+{{- if .Values.serviceAccount.create -}}
 {{- include "slvlib.serviceaccount" . | nindent 0 }}
+{{- end }}

--- a/internal/k8s/charts/slv-operator/values.yaml
+++ b/internal/k8s/charts/slv-operator/values.yaml
@@ -1,13 +1,13 @@
-# Please ensure that atleast one of ["secretBinding","k8sSecret"] are filled. 
+# Please ensure that atleast one of ["secretBinding","k8sSecret"] are filled.
 # SLV may not work as expected without a secret key or binding specified.
 
 # The secretBinding String
 secretBinding: ""
 
-# The name of the secret in the Kubernetes cluster that contains the secretKey or the secretBinding. 
+# The name of the secret in the Kubernetes cluster that contains the secretKey or the secretBinding.
 # The secretKey is to be put inside the key name "SecretKey".
 # (or)
-# The secretBinding is to be put inside the key name "SecretBinding". 
+# The secretBinding is to be put inside the key name "SecretBinding".
 # Ensure that this exists in the same namespace as the release namespace.
 k8sSecret: ""
 
@@ -53,6 +53,13 @@ env: {}
 
 # Configuration for the ServiceAccount labels and annotations
 serviceAccount:
+  # Whether to create the ServiceAccount
+  # Default: true
+  # To use a existing ServiceAccount, set this to false and set the name to the existing ServiceAccount name.
+  create: true
+  # The name of the ServiceAccount
+  # Default: slv-serviceaccount
+  name: slv-serviceaccount
   # Labels to be added to the ServiceAccount
   # Example:
   # labels:
@@ -66,13 +73,12 @@ serviceAccount:
   #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/slv-role
   annotations: {}
 
-# The volumes to be used inside the SLV pods. 
+# The volumes to be used inside the SLV pods.
 # You may need this when you are using cert-manager to inject CA certs into the SLV pods.
 # E.g. - name: cert
 #        secret:
 #        secretName: slv-webhook-server-cert
 volumes: []
-
 
 # The volume mounts to be mounted inside the SLV pods.
 # You may need this when you are using cert-manager to inject CA certs into the SLV pods.
@@ -81,13 +87,11 @@ volumes: []
 #        readOnly: true
 volumeMounts: []
 
-# The number of replicas to be used by the deployment for SLV pods. 
+# The number of replicas to be used by the deployment for SLV pods.
 replicas: 1
 
-
 webhook:
-  
-  # If set to false (left as it is), slv will automatically create TLS certificates for the webhook and set up the configuration. 
+  # If set to false (left as it is), slv will automatically create TLS certificates for the webhook and set up the configuration.
   # If set to true, you will have to create the TLS certificates and set up the configuration manually. You can
   # - Use .Values.operator.volumes and .Values.operator.volumeMounts to mount the TLS certificates inside the SLV pods.
   # - Use .Values.webhook.vwhAnnotations to set up ca injection (If using cert-manager)
@@ -97,11 +101,11 @@ webhook:
   # The name of the service that routes to the webhook server
   # Default: slv-webhook-service
   serviceName: ""
-  
+
   # Name of the Secret where TLS certs will be stored for SLV webhook
   # Default: slv-webhook-server-cert
   certSecretName: ""
-  
+
   # Name of the ValidatingWebhookConfiguration for SLV webhook
   # Default: slv-operator-validating-webhook
   validatingWebhookConfigName: ""
@@ -109,7 +113,3 @@ webhook:
   # Annotations to add to the validatingWebhookConfiguration
   # E.g. cert-manager.io/inject-ca-from-secret: "slv-webhook-server-cert"
   validatingWebhookConfigAnnotations: {}
-
-
-
-


### PR DESCRIPTION
## feat(helm): Add support for existing service accounts and configurable service account names

### Description

This PR adds support for using existing Kubernetes service accounts in the SLV operator Helm chart, enabling seamless integration with AWS EKS clusters that use **IRSA (IAM Roles for Service Accounts)**.

### Background

When creating EKS clusters with `eksctl`, users can configure IRSA by:
1. Enabling OIDC provider on the cluster
2. Creating IAM roles with required permissions
3. Having `eksctl` automatically create service accounts annotated with the IAM role ARN

Previously, the SLV Helm chart always created its own service account with a hardcoded name (`slv-serviceaccount`), making it impossible to leverage pre-configured service accounts created by `eksctl` or other infrastructure-as-code tools.

### Changes

- **Configurable service account name**: The service account name is now templated using `{{ .Values.serviceAccount.name }}` instead of being hardcoded
- **Optional service account creation**: Added `serviceAccount.create` flag to control whether the chart creates the service account


### New Configuration Options
```yaml
serviceAccount:
  # Whether to create the ServiceAccount
  # Default: true
  # To use an existing ServiceAccount, set this to false and set the name to the existing ServiceAccount name.
  create: true
  # The name of the ServiceAccount
  # Default: slv-serviceaccount
  name: slv-serviceaccount
```

### Usage Example
To use an existing service account (e.g., one created by `eksctl` with IRSA):
```yaml
serviceAccount:
  create: false
  name: my-existing-sa-with-irsa### Benefits
```


- Enables IRSA integration for AWS EKS clusters
- Allows users to manage service accounts externally (via Terraform, eksctl, etc.)
- Maintains backward compatibility with default values
- Provides flexibility for different deployment scenarios